### PR TITLE
📃 docs(第9讲 欧拉函数)：fix 

### DIFF
--- a/09_Unit/readme.md
+++ b/09_Unit/readme.md
@@ -86,26 +86,26 @@ $$
 
 我们建立一个映射关系 $f: \mathbb{Z}_{mn}^* \to{\mathbb{Z}_m^* \times \mathbb{Z}_n^*}$，它对模 $m$ 和模 $n$ 的余数 $a, b$ 都是唯一确定的，所以这个映射是定义明确的。
 
-**满射**: 由于 $m$ 和 $n$ 互质，通过中国剩余定理，我们知道对于任意的 $(a, b) \in \mathbb{Z}_m^* \times \mathbb{Z}_m^*$，考虑同余方程系统：
+**满射**: 由于 $m$ 和 $n$ 互质，通过中国剩余定理，我们知道对于任意的 $(a, b) \in \mathbb{Z}_m^* \times \mathbb{Z}_n^*$，考虑同余方程系统：
 
-$x \equiv a \pmod{n}$
+$x \equiv a \pmod{m}$
 
-$x \equiv b \pmod{m}$
+$x \equiv b \pmod{n}$
 
-，有唯一解 $x$。因此，对于 $\mathbb{Z}_m^* \times \mathbb{Z}_m^*$ 中的任意元素，都存在一个 $x$ 使得 $f(x) = (a, b)$。因此 $f$ 是满射，也就是说映射覆盖了整个集合 $\mathbb{Z}_m^* \times \mathbb{Z}_n^*$。
+，有唯一解 $x$。因此，对于 $\mathbb{Z}_m^* \times \mathbb{Z}_n^*$ 中的任意元素，都存在一个 $x$ 使得 $f(x) = (a, b)$。因此 $f$ 是满射，也就是说映射覆盖了整个集合 $\mathbb{Z}_m^* \times \mathbb{Z}_n^*$。
 
 **单射**: 假设有两个不同的元素 $x_1$ 和 $x_2$。就有 $f(x_1) = f(x_2)$，也就是 
 
-$(x_1 \mod n, x_1 \mod m) = (x_2 \mod n, x_2 \mod m)$
+$(x_1 \mod m, x_1 \mod n) = (x_2 \mod m, x_2 \mod n)$
 
-这意味着 $x_1 \equiv x_2 \pmod{n}$ 且 $x_1 \equiv x_2 \pmod{m}$。因此有 $x_1 \equiv x_2 \pmod{nm}$。因此，$x_1$ 和 $x_2$ 在模 $nm$ 下是相等的，证明了 $f$ 是单射。
+这意味着 $x_1 \equiv x_2 \pmod{m}$ 且 $x_1 \equiv x_2 \pmod{n}$。因此有 $x_1 \equiv x_2 \pmod{mn}$。因此，$x_1$ 和 $x_2$ 在模 $mn$ 下是相等的，证明了 $f$ 是单射。
 
 由于 $f$ 既是满射又是单射，则 $f$ 是双射。因此 ${\mathbb{Z}_{mn}^*}$ 和 $\mathbb{Z}_m^* \times \mathbb{Z}_n^*$ 存在双射关系，它们的元素一一对应，有 $\phi(mn) = \phi(m)\phi(n)$。
 
 </details>
 
 
-根据以上三条性质，我们可以把一个大数的欧拉函数转化成为它的因式分解后欧拉函数的乘积：若 $n$ 有质数分解 $p_1^{k_1}p_2^{k_2}...p_r^{k_r}$，其中各 $p_{i}$ 为互异的质因子， $k_i \ge 1$ 为质因子的次数），则欧拉函数在该处的值为：
+根据以上三条性质，我们可以把一个大数的欧拉函数转化成为它的因式分解后欧拉函数的乘积：若 $n$ 有质数分解 $p_1^{k_1}p_2^{k_2}...p_r^{k_r}$（其中各 $p_{i}$ 为互异的质因子， $k_i \ge 1$ 为质因子的次数），则欧拉函数在该处的值为：
 
 $$
 \phi(n)= p_1^{k_1-1}p_2^{k_2-1}...p_r^{k_r-1} (p_1 - 1) (p_2 -1)...(p_r-1) 


### PR DESCRIPTION
**修改了2.1 欧拉函数的性质 第三条性质的证明过程**
* 我们知道对于任意的 $(a, b) \in \mathbb{Z}_m^* \times \mathbb{Z}_m^\*$  -> 我们知道对于任意的 $(a, b) \in \mathbb{Z}_m^* \times \mathbb{Z}_n^*$ 
* 在证明 $f: \mathbb{Z}_{mn}^* \to{\mathbb{Z}_m^* \times \mathbb{Z}_n^\*}$ 是单射的过程中，为保持前后证明过程中与 $\mathbb{Z}_m^* \times \mathbb{Z}_n^*$ 对应，调整了部分描述中角标 $m$ 与 $n$ 的顺序。

* typo【添加左括号】： 若 $n$ 有质数分解 $p_1^{k_1}p_2^{k_2}...p_r^{k_r}$，其中各 $p_{i}$ 为互异的质因子， $k_i \ge 1$ 为质因子的次数） ->  若 $n$ 有质数分解 $p_1^{k_1}p_2^{k_2}...p_r^{k_r}$（其中各 $p_{i}$ 为互异的质因子， $k_i \ge 1$ 为质因子的次数）