### PR TITLE
Typo in euclidean division code

### DIFF
--- a/01_Integer/readme.md
+++ b/01_Integer/readme.md
@@ -102,7 +102,7 @@ def euclidean_division(a, b):
         # 调整余数确保非负
         remainder += abs(b)
         # 调整商使等式仍然成立
-        quotient += 1
+        quotient -= 1
     return quotient, remainder
 
 quotient, remainder = euclidean_division(a, b)


### PR DESCRIPTION
For example, 15 = 4 * 4 + (-1) = 3 * 4 + 3, quotient was 4 now is 3, remainder was -1 now is 3, so it should be quotient -= 1.