### PR TITLE
Fixed GM算法中二次非剩余条件判断 Update readme.md

### DIFF
--- a/MS04_ProbEncryption/readme.md
+++ b/MS04_ProbEncryption/readme.md
@@ -82,7 +82,7 @@ def generate_keys():
     q = next(primerange(10000, 11000))
     n = p * q
     x = 2
-    while is_quad_residue(x, p) and is_quad_residue(x, q):
+    while not (is_quad_residue(x, p) == False and is_quad_residue(x, q) == False):
         x += 1
     return (n, x), (p, q)
 
@@ -118,10 +118,10 @@ print("密文:", encrypted_message)
 print("解密消息:", decrypted_message)
 
 ## 输出样例
-# 公钥 (N, x): (10097063, 5)
+# 公钥 (N, x): (10097063, 17)
 # 私钥 (p, q): (1009, 10007)
 # 原始消息明文: 1010
-# 密文: [4261321, 8377247, 969148, 6082662]
+# 密文: [7768272, 4772911, 6227949, 799047]
 # 解密消息: 1010
 ```
 


### PR DESCRIPTION
原条件只能保证 x是模p的二次非剩余 或 x是模q的二次非剩余，修改后即可保证x是模p的二次非剩余 且 x是模q的二次非剩余。 原输出样例中p=1009,x = 5,可验证x是模p的二次剩余,解为244和765, pow(244,2,1009)=5,pow(765,2,1009)=5